### PR TITLE
AZ 541 HTTPS & Auth components

### DIFF
--- a/include/riak_control.hrl
+++ b/include/riak_control.hrl
@@ -1,0 +1,7 @@
+%% These two should always match, in terms of webmachine dispatcher
+%% logic, and ADMIN_BASE_PATH should always end with a /
+-define(ADMIN_BASE_PATH, "/admin/").
+-define(ADMIN_BASE_ROUTE, ["admin"]).
+
+%% Value for WWW-Authenticate header
+-define(ADMIN_AUTH_HEAD, "Basic realm=riak").

--- a/src/admin_nodes_resource.erl
+++ b/src/admin_nodes_resource.erl
@@ -1,0 +1,109 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Basic cluster membership inspection.
+%%
+%%      The resource exposes itself at `/admin/nodes'.
+-module(admin_nodes_resource).
+
+-export([
+         routes/0,
+         init/1,
+         service_available/2,
+         is_authorized/2,
+         content_types_provided/2,
+         resource_exists/2,
+         produce_json/2
+        ]).
+
+-include_lib("webmachine/include/webmachine.hrl").
+-include("riak_control.hrl").
+
+-record(ctx, {
+          base_url,
+          ring
+         }).
+
+-type context() :: #ctx{}.
+
+%%% riak_control_sup API
+
+%% @doc Get the webmachine dispatcher config for this resource.
+-spec routes() -> [webmachine_dispatcher:matchterm()].
+routes() ->
+    [{?ADMIN_BASE_ROUTE++["nodes"],
+      ?MODULE,
+      [{base_url, ?ADMIN_BASE_PATH++"nodes/"}]}].
+
+%%% Webmachine API
+
+-spec init(list()) -> {ok, context()}.
+init(Props) ->
+    {base_url, Url} = lists:keyfind(base_url, 1, Props),
+    {ok, #ctx{base_url=Url}}.
+
+-spec service_available(wrq:reqdata(), context()) ->
+         {boolean() | {halt, non_neg_integer()}, wrq:reqdata(), context()}.
+service_available(RD, Ctx) ->
+    riak_control_security:scheme_is_available(RD, Ctx).
+
+-spec is_authorized(wrq:reqdata(), context()) ->
+         {true | string(), wrq:reqdata(), context()}.
+is_authorized(RD, Ctx) ->
+    riak_control_security:enforce_auth(RD, Ctx).
+
+-spec content_types_provided(wrq:reqdata(), context()) ->
+         {[{ContentType::string(), HandlerFunction::atom()}],
+          wrq:reqdata(), context()}.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_json}], RD, Ctx}.
+
+-spec resource_exists(wrq:reqdata(), context()) ->
+         {boolean(), wrq:reqdata(), context()}.
+resource_exists(RD, Ctx) ->
+    case riak_core_ring_manager:get_my_ring() of
+        {ok, Ring} ->
+            RingCtx = Ctx#ctx{ring=Ring},
+            {true, add_node_links(RD, RingCtx), RingCtx};
+        _Error ->
+            {false, RD, Ctx}
+    end.
+
+-spec produce_json(wrq:reqdata(), context()) ->
+         {binary(), wrq:reqdata(), context()}.
+produce_json(RD, #ctx{ring=Ring}=Ctx) ->
+    %% TODO: this is not really the list of nodes we'll want (nodes
+    %% running, and connected, but not yet claiming partitions are
+    %% interesting to the UI as well), but it's a good example of
+    %% serving data over this interface
+    Members = riak_core_ring:all_members(Ring),
+    JSON = mochijson2:encode([{nodes, Members}]),
+    {JSON, RD, Ctx}.
+
+%%% Internal
+
+add_node_links(RD, #ctx{base_url=BaseUrl, ring=Ring}) ->
+    Headers = [{"Link", node_link_header(BaseUrl, Node)}
+               || Node <- riak_core_ring:all_members(Ring)],
+    wrq:merge_resp_headers(Headers, RD).
+
+node_link_header(BaseUrl, Node) ->
+    io_lib:format("<~s~s>; rel=\"node\"",
+                  [BaseUrl, mochiweb_util:quote_plus(Node)]).

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -1,0 +1,111 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc SSL and Authorization enforcement for administration URLs.
+-module(riak_control_security).
+
+-export([
+         scheme_is_available/2,
+         enforce_auth/2
+        ]).
+
+-include("riak_control.hrl").
+
+%% @doc Intended to be called from a webmachine resource's
+%% service_available function.  The return value is a valid resource
+%% return value (`{Result, ReqData, Context}').
+%%
+%% If the appenv `riak_control:admin_https_only' is `true', this
+%% function checks whether the request came in via HTTPS.  If it did
+%% not, it generates a response to redirect to the same path via HTTPS
+%% (via Location header and code 301).  If the request came in via
+%% HTTPS, or the appenv is set to `false', the request is allowed to
+%% proceed.
+-spec scheme_is_available(wrq:reqdata(), term()) ->
+         {true | {halt, 301}, wrq:reqdata(), Ctx::term()}.
+scheme_is_available(RD, Ctx) ->
+    case app_helper:get_env(riak_control, admin_https_only, true) of
+        false ->
+            %% make http-is-okay very specific, but https-is-required
+            %% catch-all, for a small bit of config safety
+            {true, RD, Ctx};
+        _True ->
+            case wrq:scheme(RD) of
+                https ->
+                    {true, RD, Ctx};
+                _ ->
+                    Host = string:join(wrq:host_tokens(RD), "."),
+                    Path = wrq:raw_path(RD),
+                    Loc = ["https://", Host, Path],
+                    {{halt, 301},
+                     wrq:set_resp_header("Location", Loc, RD),
+                     Ctx}
+            end
+    end.
+
+%% @doc Intended to be called from a webmachine resource's
+%% is_authorized function.  The return value is a valid resource
+%% return value (`{Result, ReqData, Context}').
+%%
+%% This function checks for valid authentication in the request.  If
+%% the authentication is valid, `true' is returned.  If it is invalid,
+%% the value for the response WWW-Authenticate header is returned.
+%%
+%% The correct credentials are controled by the appenv
+%% `riak_control:admin_auth'.  Valid values include:
+%%
+%%    - `erlang' :: the username should be the same as the nodename
+%%                  (e.g. `riak@127.0.0.1'), and the password should
+%%                  be the same as the node's cookie (e.g. `riak')
+enforce_auth(RD, Ctx) ->
+    case wrq:get_req_header("authorization", RD) of
+        "Basic "++Base64 ->
+            enforce_basic_auth(RD, Ctx, Base64);
+        _ ->
+            {?ADMIN_AUTH_HEAD, RD, Ctx}
+    end.
+
+enforce_basic_auth(RD, Ctx, Base64) ->
+    Str = base64:mime_decode_to_string(Base64),
+    case string:tokens(Str, ":") of
+        [User, Pass] ->
+            enforce_user_pass(RD, Ctx, User, Pass);
+        _ ->
+            {?ADMIN_AUTH_HEAD, RD, Ctx}
+    end.
+
+enforce_user_pass(RD, Ctx, User, Pass) ->
+    case valid_userpass(User, Pass) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            {?ADMIN_AUTH_HEAD, RD, Ctx}
+    end.
+
+valid_userpass(User, Pass) ->
+    case app_helper:get_env(riak_control, admin_auth) of
+        erlang ->
+            User == atom_to_list(node()) andalso
+                Pass == atom_to_list(erlang:get_cookie());
+        _Unknown ->
+            error_logger:warning_msg(
+              "Unknown admin_auth type \"~p\"", [_Unknown]),
+            false
+    end.

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -51,9 +51,14 @@ scheme_is_available(RD, Ctx) ->
                 https ->
                     {true, RD, Ctx};
                 _ ->
-                    Host = string:join(wrq:host_tokens(RD), "."),
                     Path = wrq:raw_path(RD),
-                    Loc = ["https://", Host, Path],
+                    Loc = case app_helper:get_env(riak_core, https) of
+                               undefined ->
+                                   Host = string:join(lists:reverse(wrq:host_tokens(RD)), "."),
+                                   ["https://", Host, Path];
+                               [{Host, Port}|_] ->
+                                   ["https://", Host, ":", integer_to_list(Port), Path = wrq:raw_path(RD)]
+                           end,
                     {{halt, 301},
                      wrq:set_resp_header("Location", Loc, RD),
                      Ctx}

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -57,7 +57,7 @@ scheme_is_available(RD, Ctx) ->
                                    Host = string:join(lists:reverse(wrq:host_tokens(RD)), "."),
                                    ["https://", Host, Path];
                                [{Host, Port}|_] ->
-                                   ["https://", Host, ":", integer_to_list(Port), Path = wrq:raw_path(RD)]
+                                   ["https://", Host, ":", integer_to_list(Port), wrq:raw_path(RD)]
                            end,
                     {{halt, 301},
                      wrq:set_resp_header("Location", Loc, RD),

--- a/src/riak_control_sup.erl
+++ b/src/riak_control_sup.erl
@@ -43,7 +43,8 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    Resources = [{rekon, rekon_resource}],
+    Resources = [{rekon, rekon_resource},
+                 {admin, admin_nodes_resource}],
     Routes = lists:append([routes(E, M) || {E, M} <- Resources]),
     [ webmachine_router:add_route(R) || R <- Routes ],
 


### PR DESCRIPTION
`admin_nodes_resource` is just an example of how to force a request over to HTTPS, and then also require Basic authorization for it.  The user/pass for the basic auth is <nodename>/<cookie>.  You'll also want this patch from the `control` branch on my personal riak fork:

https://github.com/beerriot/riak/commit/b5cb1076e18c8d69ce358646a9e976b98a1364e2
