### PR TITLE
Centralize target_node in riak_control as utility.

### DIFF
--- a/src/admin_cluster.erl
+++ b/src/admin_cluster.erl
@@ -102,8 +102,7 @@ to_json (Req,C=join) ->
 
 %% mark a node in the cluster as down
 to_json (Req,C=down) ->
-    NodeStr=dict:fetch(node,wrq:path_info(Req)),
-    Node=list_to_existing_atom(NodeStr),
+    Node=riak_control:target_node(Req),
     Result=riak_core:down(Node),
     cluster_action_result(Result,Req,C).
 

--- a/src/riak_control.erl
+++ b/src/riak_control.erl
@@ -22,6 +22,7 @@
 -module(riak_control).
 
 -export([
+         target_node/1,
          is_app_up/1,
          priv_dir/0
         ]).
@@ -35,3 +36,7 @@ is_app_up(App) ->
 -spec priv_dir() -> string().
 priv_dir() ->
     code:priv_dir(?MODULE).
+
+%% @doc Return the target node for a particular action.
+target_node (Req) ->
+    list_to_existing_atom(dict:fetch(node,wrq:path_info(Req))).


### PR DESCRIPTION
Extremely minor change; moves target_node to riak_control and replaces other implementation with function call.
