### PR TITLE
Ensure that the correct content-type is returned.

### DIFF
--- a/src/admin_gui.erl
+++ b/src/admin_gui.erl
@@ -75,12 +75,19 @@ is_authorized (RD,C) ->
 
 %% return the list of available content types for webmachine
 content_types_provided (Req,Ctx) ->
-    {?CONTENT_TYPES,Req,Ctx}.
+    Index = file_path(Req),
+    MimeType = webmachine_util:guess_mime(Index),
+    {[{MimeType, to_resource}],Req, Ctx}.
+
+%% return file path 
+file_path(Req) -> 
+    Path=wrq:path_tokens(Req),
+    Index=filename:join([riak_control:priv_dir(),"admin"] ++ Path),
+    Index.
 
 %% loads a resource file from disk and returns it
 get_file (Req) ->
-    Path=wrq:path_tokens(Req),
-    Index=filename:join([riak_control:priv_dir(),"admin"] ++ Path),
+    Index = file_path(Req),
     {ok,Source}=file:read_file(Index),
     Source.
 

--- a/src/admin_gui.erl
+++ b/src/admin_gui.erl
@@ -82,8 +82,7 @@ content_types_provided (Req,Ctx) ->
 %% return file path 
 file_path(Req) -> 
     Path=wrq:path_tokens(Req),
-    Index=filename:join([riak_control:priv_dir(),"admin"] ++ Path),
-    Index.
+    filename:join([riak_control:priv_dir(),"admin"] ++ Path).
 
 %% loads a resource file from disk and returns it
 get_file (Req) ->


### PR DESCRIPTION
Currently, web browsers such as Chrome throw warnings for each resource which is returned with the wrong content type. Modify the content-types-provided method to inspect the resource and return a best guess at the appropriate mime-type.

@massung @jgnewman 
