### PR TITLE
fixed early timeouts for some clients

### DIFF
--- a/priv/admin/js/pjax.js
+++ b/priv/admin/js/pjax.js
@@ -1,8 +1,16 @@
 // jquery.pjax.js
 // copyright chris wanstrath
 // https://github.com/defunkt/jquery-pjax
+// Modified by Basho Technologies to fix a timeout issue for some clients.
 
 (function($){
+
+// The following variable is in milliseconds.
+// It controls the ajax timeouts for page fetching attempts.
+// The pjax default was 650 but this is too early in some use cases.
+// We're setting it high here to account for most foreseeable circumstances.
+// - Basho
+var ajaxTimeout = 10000;
 
 // When called on a link, fetches the href with ajax into the
 // container specified as the first parameter or with the data-pjax
@@ -180,7 +188,7 @@ var pjax = $.pjax = function( options ) {
 
 
 pjax.defaults = {
-  timeout: 650,
+  timeout: ajaxTimeout, // was previously 650 - Basho
   push: true,
   replace: false,
   // We want the browser to maintain two separate internal caches: one for


### PR DESCRIPTION
The issue we see occasionally where the user tries to fetch a page and is taken to a style-less template page has been solved in each case by lengthening the timeout on the ajax request that fetches the page.  This fix significantly lengthens the global page-fetching timeout and is done in such a way that it is easily modified if necessary.
