### PR TITLE
Update riak_control instructions for SSL.

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,12 +23,9 @@ to change the HTTPS port to something else:
 
 : {https, [ {"127.0.0.1", 8069} ]}
 
-If you have Riak 1.0.2 or later, then when you installed Riak a
-default, self-signed SSL certificate was created for you and put
-into the etc/ configuration folder for Riak. If these files are
-not there, you will need to either generate your own self-signed
-certificate (http://www.akadia.com/services/ssh_test_certificate.html)
-or modify the app.config to point to your own:
+You will also need to generate your own self-signed certificate
+(http://www.akadia.com/services/ssh_test_certificate.html) or modify the
+app.config to point to your own:
 
 : {ssl, [ {certfile, "./etc/cert.pem"},
 :         {keyfile, "./etc/key.pem"}


### PR DESCRIPTION
@jaredmorrow 

Extremely minor update to riak_control instructions clarifying that you will need to provide your own SSL certificate.
