### PR TITLE
Re-export admin_ring:node_ring_details/2 back

### DIFF
--- a/src/admin_node.erl
+++ b/src/admin_node.erl
@@ -86,5 +86,5 @@ get_node_details(Req,C) ->
     Node=target_node(Req),
     {ok,Ring}=riak_core_ring_manager:get_my_ring(),
     Indices=rpc:call(Node,riak_core_ring,my_indices,[Ring]),
-    PS=[{struct,admin_ring:node_ring_details(Ring,{P,Node})} || P <- Indices],
+    PS=[{struct,admin_ring:node_ring_details(P,Node)} || P <- Indices],
     {mochijson2:encode(PS),Req,C}.

--- a/src/admin_ring.erl
+++ b/src/admin_ring.erl
@@ -25,7 +25,8 @@
          to_json/2,
          is_authorized/2,
          service_available/2,
-         forbidden/2
+         forbidden/2,
+         node_ring_details/2
         ]).
 
 %% riak_control and webmachine dependencies


### PR DESCRIPTION
Hello.
I'm not so sure with my patch actually. To start with it's clear that unexported function admin_ring:node_ring_details/2 is called from another module, so at least we should properly export it (or remove its usage from admin_node module). Also I suspect that even if we just properly export  it then it still called wrongly - arity is the same but it seems that variable types does not match. So please take a closer look.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
