### PR TITLE
Add CSRF token prevention.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: rel deps test
+
+all: deps compile
+
+compile:
+	@./rebar compile
+
+deps:
+	@./rebar get-deps
+
+clean:
+	@./rebar clean
+
+distclean: clean
+	@./rebar delete-deps
+
+test: all
+	@./rebar skip_deps=true eunit

--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -139,7 +139,7 @@ $(document).ready(function () {
     }
 
     function perform_node_action(action) {
-        var csrf_token = $('meta[name=csrf-token]').attr('content');
+        var csrf_token = $('meta[name=csrf_token]').attr('content');
 
         $.ajax({
             url: action,

--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -145,10 +145,14 @@ $(document).ready(function () {
             url: action,
             type: 'POST',
             data: "csrf_token=" + encodeURIComponent(csrf_token),
+            dataType: 'application/json',
             complete: function (x,y) {
                 var err, errortextbox, errorlinkbox;
                 if (y.toLowerCase() === 'error') {
-                    err = x.responseText.split('<title>')[1].split('</title>')[0] + ' <a class="monospace">-></a> ' + this.url + '.';
+                    // TODO: This wasn't returning anything meaningful,
+                    // so I'm hardcoding a string until we can get
+                    // actual useful messages in.
+                    err = "An error occurred";
                     $('#node-error .error-text').html(err);
                     $('#node-error .error-link').html('View in Logs &raquo;');
                     $('#node-error').show();

--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -144,13 +144,13 @@ $(document).ready(function () {
         $.ajax({
             url: action,
             type: 'POST',
-            data: "csrf_token=" + csrf_token,
+            data: "csrf_token=" + encodeURIComponent(csrf_token),
             complete: function (x,y) {
                 var err, errortextbox, errorlinkbox;
                 if (y.toLowerCase() === 'error') {
                     err = x.responseText.split('<title>')[1].split('</title>')[0] + ' <a class="monospace">-></a> ' + this.url + '.';
                     $('#node-error .error-text').html(err);
-                    $('#node-error .error-link').html('View in Logs &raquo;')
+                    $('#node-error .error-link').html('View in Logs &raquo;');
                     $('#node-error').show();
                 }
                 enable_adding((y.toLowerCase() === 'success') ? true : false);

--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -139,9 +139,12 @@ $(document).ready(function () {
     }
 
     function perform_node_action(action) {
+        var csrf_token = $('meta[name=csrf-token]').attr('content');
+
         $.ajax({
             url: action,
-            dataType: 'json',
+            type: 'POST',
+            data: "csrf_token=" + csrf_token,
             complete: function (x,y) {
                 var err, errortextbox, errorlinkbox;
                 if (y.toLowerCase() === 'error') {

--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -145,7 +145,7 @@ $(document).ready(function () {
             url: action,
             type: 'POST',
             data: "csrf_token=" + encodeURIComponent(csrf_token),
-            dataType: 'application/json',
+            dataType: 'json',
             complete: function (x,y) {
                 var err, errortextbox, errorlinkbox;
                 if (y.toLowerCase() === 'error') {

--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,8 @@
        {webmachine, ".*",
         {git, "git://github.com/basho/webmachine", {branch, "master"}}},
        {riak_core, ".*",
-        {git, "git://github.com/basho/riak_core", {branch, "master"}}}
+        {git, "git://github.com/basho/riak_core", {branch, "master"}}},
+       {erlydtl, ".*",
+        {git, "git://github.com/evanmiller/erlydtl.git", {branch, "master"}}}
        ]}.
 

--- a/src/admin_cluster.erl
+++ b/src/admin_cluster.erl
@@ -35,27 +35,27 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:cluster_route(["list"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) ->
+init(Action) ->
     {ok,Action}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% get a list of all the nodes in the ring and their status
-to_json (Req,C) ->
+to_json(Req,C) ->
     {ok,_V,Nodes}=riak_control_session:get_nodes(),
     Status=[{struct,[{"name",Node#member_info.node},
                      {"status",Node#member_info.status},

--- a/src/admin_cluster.erl
+++ b/src/admin_cluster.erl
@@ -24,7 +24,8 @@
          content_types_provided/2,
          to_json/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -41,6 +42,10 @@ routes() ->
 %% entry-point for the resource from webmachine
 init(Action) ->
     {ok,Action}.
+
+%% validate origin
+forbidden(RD, C) ->
+    {riak_control_security:is_null_origin(RD), RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available(RD,C) ->

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -41,8 +41,7 @@ routes() ->
     [{admin_routes:cluster_route(["down",node]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init(Action) ->
-    {ok,Action}.
+init([]) -> {ok,undefined}.
 
 %% alow post
 allowed_methods(RD, C) ->

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -18,13 +18,15 @@
 %%
 %% -------------------------------------------------------------------
 
--module(admin_cluster).
+-module(admin_cluster_down).
 -export([routes/0,
          init/1,
+         allowed_methods/2,
          content_types_provided/2,
-         to_json/2,
+         process_post/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -36,11 +38,15 @@
 
 %% defines the webmachine routes this module handles
 routes () ->
-    [{admin_routes:cluster_route(["list"]),?MODULE,[]}].
+    [{admin_routes:cluster_route(["down",node]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
 init (Action) ->
     {ok,Action}.
+
+%% alow post
+allowed_methods(RD, C) ->
+    {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available (RD,C) ->
@@ -50,23 +56,18 @@ service_available (RD,C) ->
 is_authorized (RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
+%% validate csfr_token
+forbidden(RD, C) ->
+    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+
 %% return the list of available content types for webmachine
 content_types_provided (Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
-%% get a list of all the nodes in the ring and their status
-to_json (Req,C) ->
-    {ok,_V,Nodes}=riak_control_session:get_nodes(),
-    Status=[{struct,[{"name",Node#member_info.node},
-                     {"status",Node#member_info.status},
-                     {"reachable",Node#member_info.reachable},
-                     {"ring_pct",Node#member_info.ring_pct},
-                     {"pending_pct",Node#member_info.pending_pct},
-                     {"mem_total",Node#member_info.mem_total},
-                     {"mem_used",Node#member_info.mem_used},
-                     {"mem_erlang",Node#member_info.mem_erlang},
-                     {"me",Node#member_info.node == node()}
-                    ]}
-            || Node=#member_info{} <- Nodes],
-    {mochijson2:encode(Status),Req,C}.
+%% mark a node in the cluster as down
+process_post (Req,C) ->
+    NodeStr=dict:fetch(node,wrq:path_info(Req)),
+    Node=list_to_existing_atom(NodeStr),
+    Result=riak_core:down(Node),
+    riak_control_formatting:cluster_action_result(Result,Req,C).
 

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -22,7 +22,6 @@
 -export([routes/0,
          init/1,
          allowed_methods/2,
-         content_types_provided/2,
          process_post/2,
          is_authorized/2,
          service_available/2,
@@ -57,11 +56,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
-
-%% return the list of available content types for webmachine
-content_types_provided(Req,C) ->
-    {?CONTENT_TYPES,Req,C}.
+    {riak_control_security:is_null_origin(RD) or not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% mark a node in the cluster as down
 process_post(Req,C) ->

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -57,7 +57,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
 content_types_provided(Req,C) ->

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -37,11 +37,11 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:cluster_route(["down",node]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) ->
+init(Action) ->
     {ok,Action}.
 
 %% alow post
@@ -49,11 +49,11 @@ allowed_methods(RD, C) ->
     {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% validate csfr_token
@@ -61,11 +61,11 @@ forbidden(RD, C) ->
     {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% mark a node in the cluster as down
-process_post (Req,C) ->
+process_post(Req,C) ->
     NodeStr=dict:fetch(node,wrq:path_info(Req)),
     Node=list_to_existing_atom(NodeStr),
     Result=riak_core:down(Node),

--- a/src/admin_cluster_down.erl
+++ b/src/admin_cluster_down.erl
@@ -63,5 +63,5 @@ process_post(Req,C) ->
     NodeStr=dict:fetch(node,wrq:path_info(Req)),
     Node=list_to_existing_atom(NodeStr),
     Result=riak_core:down(Node),
-    riak_control_formatting:cluster_action_result(Result,Req,C).
+    riak_control_formatting:action_result(Result,Req,C).
 

--- a/src/admin_cluster_join.erl
+++ b/src/admin_cluster_join.erl
@@ -37,11 +37,11 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:cluster_route(["join",node]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) ->
+init(Action) ->
     {ok,Action}.
 
 %% alow post
@@ -49,11 +49,11 @@ allowed_methods(RD, C) ->
     {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% validate csfr_token
@@ -61,11 +61,11 @@ forbidden(RD, C) ->
     {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% join this node to the cluster of another ring
-process_post (Req,C) ->
+process_post(Req,C) ->
     {ok,Ring}=riak_core_ring_manager:get_my_ring(),
     NodeStr=dict:fetch(node,wrq:path_info(Req)),
     Node=list_to_atom(NodeStr),

--- a/src/admin_cluster_join.erl
+++ b/src/admin_cluster_join.erl
@@ -57,7 +57,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
 content_types_provided(Req,C) ->

--- a/src/admin_cluster_join.erl
+++ b/src/admin_cluster_join.erl
@@ -41,8 +41,7 @@ routes() ->
     [{admin_routes:cluster_route(["join",node]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init(Action) ->
-    {ok,Action}.
+init([]) -> {ok,undefined}.
 
 %% alow post
 allowed_methods(RD, C) ->

--- a/src/admin_cluster_join.erl
+++ b/src/admin_cluster_join.erl
@@ -71,9 +71,9 @@ process_post(Req,C) ->
         [_Me] ->
             %% we're a single-node cluster, join the other guy...
             Result=riak_core:join(Node),
-            riak_control_formatting:cluster_action_result(Result,Req,C);
+            riak_control_formatting:action_result(Result,Req,C);
         _ ->
             %% we have a cluster, make them join us
             Result=rpc:call(Node,riak_core,join,[node()]),
-            riak_control_formatting:cluster_action_result(Result,Req,C)
+            riak_control_formatting:action_result(Result,Req,C)
     end.

--- a/src/admin_cluster_join.erl
+++ b/src/admin_cluster_join.erl
@@ -22,7 +22,6 @@
 -export([routes/0,
          init/1,
          allowed_methods/2,
-         content_types_provided/2,
          process_post/2,
          is_authorized/2,
          service_available/2,
@@ -57,11 +56,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
-
-%% return the list of available content types for webmachine
-content_types_provided(Req,C) ->
-    {?CONTENT_TYPES,Req,C}.
+    {riak_control_security:is_null_origin(RD) or not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% join this node to the cluster of another ring
 process_post(Req,C) ->

--- a/src/admin_fallbacks.erl
+++ b/src/admin_fallbacks.erl
@@ -1,0 +1,86 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(admin_fallbacks).
+-export([routes/0,
+         init/1,
+         content_types_provided/2,
+         to_resource/2,
+         is_authorized/2,
+         service_available/2,
+         forbidden/2
+        ]).
+
+%% riak_control and webmachine dependencies
+-include_lib("riak_control/include/riak_control.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+%% mappings to the various content types supported for this resource
+-define(CONTENT_TYPES,[{"application/json", to_resource}]).
+
+%% defines the webmachine routes this module handles
+routes() -> [{admin_routes:admin_route(["fallbacks"]),?MODULE,[]}].
+
+%% entry-point for the resource from webmachine
+init([]) -> {ok,undefined}.
+
+%% validate origin
+forbidden(RD, C) ->
+    {riak_control_security:is_null_origin(RD), RD, C}.
+
+%% redirect to SSL port if using HTTP
+service_available(RD,C) ->
+    riak_control_security:scheme_is_available(RD,C).
+
+%% validate username and password
+is_authorized(RD,C) ->
+    riak_control_security:enforce_auth(RD,C).
+
+%% return the list of available content types for webmachine
+content_types_provided(Req,C) ->
+    {?CONTENT_TYPES,Req,C}.
+
+%% true if the node is running riak_control
+redirect_loc(Node) ->
+    rpc:call(Node,riak_control_security,https_redirect_loc,[[]]).
+
+%% don't use this node as a fallback, must be valid and reachable
+find_fallbacks(Nodes) ->
+    lists:foldl(fun (#member_info{node=Node,status=valid,reachable=true},Acc) ->
+                        case Node == node() of
+                            true -> Acc;
+                            false ->
+                                case redirect_loc(Node) of
+                                    {ok,Loc} ->
+                                        URI=lists:flatten(Loc),
+                                        [list_to_binary(URI)|Acc];
+                                    _ -> Acc
+                                end
+                        end;
+                    (_,Acc) -> Acc
+                end,
+                [],
+                Nodes).
+
+%% find another node in the cluster that is running the GUI
+to_resource(Req,Ctx) ->
+    {ok,_V,Nodes}=riak_control_session:get_nodes(),
+    NodeURIs=find_fallbacks(Nodes),
+    {mochijson2:encode(NodeURIs),Req,Ctx}.

--- a/src/admin_gui.erl
+++ b/src/admin_gui.erl
@@ -44,7 +44,6 @@
 %% defines the webmachine routes this module handles
 routes() ->
     [{admin_routes:admin_route([]),?MODULE,index},
-     {admin_routes:admin_route(["fallbacks"]),?MODULE,fallback},
      {admin_routes:admin_route(["ui",'*']),?MODULE,undefined},
      {admin_routes:admin_route(["ui","index.html"]),?MODULE,oldindex}
     ].
@@ -91,43 +90,11 @@ get_file(Req) ->
     {ok,Source}=file:read_file(Index),
     Source.
 
-%% true if the node is running riak_control
-redirect_loc(Node) ->
-    rpc:call(Node,riak_control_security,https_redirect_loc,[[]]).
-
-%% don't use this node as a fallback, must be valid and reachable
-find_fallbacks(Nodes) ->
-    lists:foldl(fun (#member_info{node=Node,status=valid,reachable=true},Acc) ->
-                        case Node == node() of
-                            true -> Acc;
-                            false ->
-                                case redirect_loc(Node) of
-                                    {ok,Loc} ->
-                                        URI=lists:flatten(Loc),
-                                        [list_to_binary(URI)|Acc];
-                                    _ -> Acc
-                                end
-                        end;
-                    (_,Acc) -> Acc
-                end,
-                [],
-                Nodes).
-
-%% find another node in the cluster that is running the GUI
-to_resource(Req,Ctx=fallback) ->
-    {ok,_V,Nodes}=riak_control_session:get_nodes(),
-    NodeURIs=find_fallbacks(Nodes),
-    {mochijson2:encode(NodeURIs),Req,Ctx};
-
 %% respond to an index request
 to_resource(Req,Ctx=index) ->
     Token = riak_control_security:csrf_token(Req, Ctx),
     {ok, Content} = index_dtl:render([{csrf_token, Token}]),
     {Content, wrq:set_resp_header("Set-Cookie", "csrf_token="++Token++"; secure; httponly", Req), Ctx};
-
-%% respond to a file request
-to_resource(Req,Ctx=oldindex) ->
-    {"a",Req,Ctx};
 
 %% respond to a file request
 to_resource(Req,Ctx) ->

--- a/src/admin_gui.erl
+++ b/src/admin_gui.erl
@@ -58,6 +58,8 @@ is_authorized (RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% return the list of available content types for webmachine
+content_types_provided (Req,Ctx=index) ->
+    {[{"text/html", to_resource}],Req, Ctx};
 content_types_provided (Req,Ctx) ->
     Index = file_path(Req),
     MimeType = webmachine_util:guess_mime(Index),

--- a/src/admin_gui.erl
+++ b/src/admin_gui.erl
@@ -71,17 +71,17 @@ file_path(Req) ->
     filename:join([riak_control:priv_dir(),"admin"] ++ Path).
 
 %% loads a resource file from disk and returns it
-get_file (Req) ->
+get_file(Req) ->
     Index = file_path(Req),
     {ok,Source}=file:read_file(Index),
     Source.
 
 %% true if the node is running riak_control
-redirect_loc (Node) ->
+redirect_loc(Node) ->
     rpc:call(Node,riak_control_security,https_redirect_loc,[[]]).
 
 %% don't use this node as a fallback, must be valid and reachable
-find_fallbacks (Nodes) ->
+find_fallbacks(Nodes) ->
     lists:foldl(fun (#member_info{node=Node,status=valid,reachable=true},Acc) ->
                         case Node == node() of
                             true -> Acc;
@@ -99,17 +99,17 @@ find_fallbacks (Nodes) ->
                 Nodes).
 
 %% find another node in the cluster that is running the GUI
-to_resource (Req,Ctx=fallback) ->
+to_resource(Req,Ctx=fallback) ->
     {ok,_V,Nodes}=riak_control_session:get_nodes(),
     NodeURIs=find_fallbacks(Nodes),
     {mochijson2:encode(NodeURIs),Req,Ctx};
 
 %% respond to an index request
-to_resource (Req,Ctx=index) ->
+to_resource(Req,Ctx=index) ->
     Token = riak_control_security:csrf_token(Req, Ctx),
     {ok, Content} = index_dtl:render([{csrf_token, Token}]),
     {Content, wrq:set_resp_header("Set-Cookie", "csrf_token="++Token++"; secure; httponly", Req), Ctx};
 
 %% respond to a file request
-to_resource (Req,Ctx) ->
+to_resource(Req,Ctx) ->
     {get_file(Req),Req,Ctx}.

--- a/src/admin_node.erl
+++ b/src/admin_node.erl
@@ -35,49 +35,49 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:node_route(["ping"]),?MODULE,ping},
      {admin_routes:node_route(["stats"]),?MODULE,stats},
      {admin_routes:node_route(["details"]),?MODULE,details}].
 
 %% entry-point for the resource from webmachine
-init (Action) -> {ok,Action}.
+init(Action) -> {ok,Action}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% get the target node for the action
-target_node (Req) ->
+target_node(Req) ->
     list_to_existing_atom(dict:fetch(node,wrq:path_info(Req))).
 
 %% most node actions are simple rpc calls
-to_json (Req,C=ping) ->
+to_json(Req,C=ping) ->
     riak_control_rpc:perform_rpc_action(Req,C,net_adm,ping,[node()]);
-to_json (Req,C=stats) ->
+to_json(Req,C=stats) ->
     get_node_stats(Req,C);
-to_json (Req,C=details) ->
+to_json(Req,C=details) ->
     get_node_details(Req,C);
-to_json (Req,C) ->
+to_json(Req,C) ->
     riak_control_rpc:node_action_result({error,{struct,[{unknown_action,C}]}},Req,C).
 
 %% stats aren't perfectly formatted json (TODO: fix that!)
-get_node_stats (Req,C) ->
+get_node_stats(Req,C) ->
     Node=target_node(Req),
     Result=rpc:call(Node,riak_kv_stat,get_stats,[]),
     Stats=proplists:delete(disk,Result),
     {mochijson2:encode({struct,Stats}),Req,C}.
 
 %% details are ring information for this particular node
-get_node_details (Req,C) ->
+get_node_details(Req,C) ->
     Node=target_node(Req),
     {ok,Ring}=riak_core_ring_manager:get_my_ring(),
     Indices=rpc:call(Node,riak_core_ring,my_indices,[Ring]),

--- a/src/admin_node.erl
+++ b/src/admin_node.erl
@@ -72,7 +72,7 @@ to_json(Req,C=stats) ->
 to_json(Req,C=details) ->
     get_node_details(Req,C);
 to_json(Req,C) ->
-    riak_control_rpc:node_action_result({error,{struct,[{unknown_action,C}]}},Req,C).
+    riak_control_formatting:action_result({error,unknown_action},Req,C).
 
 %% stats aren't perfectly formatted json (TODO: fix that!)
 get_node_stats(Req,C) ->

--- a/src/admin_node.erl
+++ b/src/admin_node.erl
@@ -24,7 +24,8 @@
          content_types_provided/2,
          to_json/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -42,6 +43,10 @@ routes() ->
 
 %% entry-point for the resource from webmachine
 init(Action) -> {ok,Action}.
+
+%% validate origin
+forbidden(RD, C) ->
+    {riak_control_security:is_null_origin(RD), RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available(RD,C) ->

--- a/src/admin_node_leave.erl
+++ b/src/admin_node_leave.erl
@@ -57,7 +57,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
 content_types_provided(Req,C) ->

--- a/src/admin_node_leave.erl
+++ b/src/admin_node_leave.erl
@@ -41,7 +41,7 @@ routes() ->
     [{admin_routes:node_route(["leave"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init(Action) -> {ok,Action}.
+init([]) -> {ok,undefined}.
 
 %% alow post
 allowed_methods(RD, C) ->

--- a/src/admin_node_leave.erl
+++ b/src/admin_node_leave.erl
@@ -37,22 +37,22 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:node_route(["leave"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) -> {ok,Action}.
+init(Action) -> {ok,Action}.
 
 %% alow post
 allowed_methods(RD, C) ->
     {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% validate csfr_token
@@ -60,9 +60,9 @@ forbidden(RD, C) ->
     {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% most node actions are simple rpc calls
-process_post (Req,C) ->
+process_post(Req,C) ->
     riak_control_rpc:perform_rpc_action(Req,C,riak_core,leave,[]).

--- a/src/admin_node_leave.erl
+++ b/src/admin_node_leave.erl
@@ -22,7 +22,6 @@
 -export([routes/0,
          init/1,
          allowed_methods/2,
-         content_types_provided/2,
          process_post/2,
          is_authorized/2,
          service_available/2,
@@ -57,11 +56,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
-
-%% return the list of available content types for webmachine
-content_types_provided(Req,C) ->
-    {?CONTENT_TYPES,Req,C}.
+    {riak_control_security:is_null_origin(RD) or not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% most node actions are simple rpc calls
 process_post(Req,C) ->

--- a/src/admin_node_leave.erl
+++ b/src/admin_node_leave.erl
@@ -18,13 +18,15 @@
 %%
 %% -------------------------------------------------------------------
 
--module(admin_cluster).
+-module(admin_node_leave).
 -export([routes/0,
          init/1,
+         allowed_methods/2,
          content_types_provided/2,
-         to_json/2,
+         process_post/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -36,11 +38,14 @@
 
 %% defines the webmachine routes this module handles
 routes () ->
-    [{admin_routes:cluster_route(["list"]),?MODULE,[]}].
+    [{admin_routes:node_route(["leave"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) ->
-    {ok,Action}.
+init (Action) -> {ok,Action}.
+
+%% alow post
+allowed_methods(RD, C) ->
+    {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available (RD,C) ->
@@ -50,23 +55,14 @@ service_available (RD,C) ->
 is_authorized (RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
+%% validate csfr_token
+forbidden(RD, C) ->
+    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+
 %% return the list of available content types for webmachine
 content_types_provided (Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
-%% get a list of all the nodes in the ring and their status
-to_json (Req,C) ->
-    {ok,_V,Nodes}=riak_control_session:get_nodes(),
-    Status=[{struct,[{"name",Node#member_info.node},
-                     {"status",Node#member_info.status},
-                     {"reachable",Node#member_info.reachable},
-                     {"ring_pct",Node#member_info.ring_pct},
-                     {"pending_pct",Node#member_info.pending_pct},
-                     {"mem_total",Node#member_info.mem_total},
-                     {"mem_used",Node#member_info.mem_used},
-                     {"mem_erlang",Node#member_info.mem_erlang},
-                     {"me",Node#member_info.node == node()}
-                    ]}
-            || Node=#member_info{} <- Nodes],
-    {mochijson2:encode(Status),Req,C}.
-
+%% most node actions are simple rpc calls
+process_post (Req,C) ->
+    riak_control_rpc:perform_rpc_action(Req,C,riak_core,leave,[]).

--- a/src/admin_node_stop.erl
+++ b/src/admin_node_stop.erl
@@ -37,22 +37,22 @@
 -define(CONTENT_TYPES,[{"application/json",to_json}]).
 
 %% defines the webmachine routes this module handles
-routes () ->
+routes() ->
     [{admin_routes:node_route(["stop"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) -> {ok,Action}.
+init(Action) -> {ok,Action}.
 
 %% alow post
 allowed_methods(RD, C) ->
     {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
-service_available (RD,C) ->
+service_available(RD,C) ->
     riak_control_security:scheme_is_available(RD,C).
 
 %% validate username and password
-is_authorized (RD,C) ->
+is_authorized(RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
 %% validate csfr_token
@@ -60,9 +60,9 @@ forbidden(RD, C) ->
     {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
-content_types_provided (Req,C) ->
+content_types_provided(Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
 %% most node actions are simple rpc calls
-process_post (Req,C) ->
+process_post(Req,C) ->
     riak_control_rpc:perform_rpc_action(Req,C,riak_core,stop,[]).

--- a/src/admin_node_stop.erl
+++ b/src/admin_node_stop.erl
@@ -18,13 +18,15 @@
 %%
 %% -------------------------------------------------------------------
 
--module(admin_cluster).
+-module(admin_node_stop).
 -export([routes/0,
          init/1,
+         allowed_methods/2,
          content_types_provided/2,
-         to_json/2,
+         process_post/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -36,11 +38,14 @@
 
 %% defines the webmachine routes this module handles
 routes () ->
-    [{admin_routes:cluster_route(["list"]),?MODULE,[]}].
+    [{admin_routes:node_route(["stop"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init (Action) ->
-    {ok,Action}.
+init (Action) -> {ok,Action}.
+
+%% alow post
+allowed_methods(RD, C) ->
+    {['POST'], RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available (RD,C) ->
@@ -50,23 +55,14 @@ service_available (RD,C) ->
 is_authorized (RD,C) ->
     riak_control_security:enforce_auth(RD,C).
 
+%% validate csfr_token
+forbidden(RD, C) ->
+    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+
 %% return the list of available content types for webmachine
 content_types_provided (Req,C) ->
     {?CONTENT_TYPES,Req,C}.
 
-%% get a list of all the nodes in the ring and their status
-to_json (Req,C) ->
-    {ok,_V,Nodes}=riak_control_session:get_nodes(),
-    Status=[{struct,[{"name",Node#member_info.node},
-                     {"status",Node#member_info.status},
-                     {"reachable",Node#member_info.reachable},
-                     {"ring_pct",Node#member_info.ring_pct},
-                     {"pending_pct",Node#member_info.pending_pct},
-                     {"mem_total",Node#member_info.mem_total},
-                     {"mem_used",Node#member_info.mem_used},
-                     {"mem_erlang",Node#member_info.mem_erlang},
-                     {"me",Node#member_info.node == node()}
-                    ]}
-            || Node=#member_info{} <- Nodes],
-    {mochijson2:encode(Status),Req,C}.
-
+%% most node actions are simple rpc calls
+process_post (Req,C) ->
+    riak_control_rpc:perform_rpc_action(Req,C,riak_core,stop,[]).

--- a/src/admin_node_stop.erl
+++ b/src/admin_node_stop.erl
@@ -57,7 +57,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:validate_csrf_token(RD, C), RD, C}.
+    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% return the list of available content types for webmachine
 content_types_provided(Req,C) ->

--- a/src/admin_node_stop.erl
+++ b/src/admin_node_stop.erl
@@ -22,7 +22,6 @@
 -export([routes/0,
          init/1,
          allowed_methods/2,
-         content_types_provided/2,
          process_post/2,
          is_authorized/2,
          service_available/2,
@@ -57,11 +56,7 @@ is_authorized(RD,C) ->
 
 %% validate csfr_token
 forbidden(RD, C) ->
-    {not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
-
-%% return the list of available content types for webmachine
-content_types_provided(Req,C) ->
-    {?CONTENT_TYPES,Req,C}.
+    {riak_control_security:is_null_origin(RD) or not riak_control_security:is_valid_csrf_token(RD, C), RD, C}.
 
 %% most node actions are simple rpc calls
 process_post(Req,C) ->

--- a/src/admin_node_stop.erl
+++ b/src/admin_node_stop.erl
@@ -41,7 +41,7 @@ routes() ->
     [{admin_routes:node_route(["stop"]),?MODULE,[]}].
 
 %% entry-point for the resource from webmachine
-init(Action) -> {ok,Action}.
+init([]) -> {ok,undefined}.
 
 %% alow post
 allowed_methods(RD, C) ->

--- a/src/admin_overview.erl
+++ b/src/admin_overview.erl
@@ -24,7 +24,8 @@
          content_types_provided/2,
          to_json/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -40,6 +41,10 @@ routes () -> [{admin_routes:admin_route(["overview"]),?MODULE,[]}].
 %% entry-point for the resource from webmachine
 init ([]) ->
     {ok,undefined}.
+
+%% validate origin
+forbidden(RD, C) ->
+    {riak_control_security:is_null_origin(RD), RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available (RD,C) ->

--- a/src/admin_ring.erl
+++ b/src/admin_ring.erl
@@ -24,7 +24,8 @@
          content_types_provided/2,
          to_json/2,
          is_authorized/2,
-         service_available/2
+         service_available/2,
+         forbidden/2
         ]).
 
 %% riak_control and webmachine dependencies
@@ -45,6 +46,10 @@ routes () ->
 init ([]) ->
     {ok,_V,Partitions}=riak_control_session:get_partitions(),
     {ok,Partitions}.
+
+%% validate origin
+forbidden(RD, C) ->
+    {riak_control_security:is_null_origin(RD), RD, C}.
 
 %% redirect to SSL port if using HTTP
 service_available (RD,C) ->

--- a/src/riak_control_formatting.erl
+++ b/src/riak_control_formatting.erl
@@ -28,15 +28,15 @@
 %% TODO: combine these two.
 
 %% all actions return the same format
-cluster_action_result (Error={error,_},Req,C) ->
+cluster_action_result(Error={error,_},Req,C) ->
     {{error,mochijson2:encode({struct,[Error]})},Req,C};
-cluster_action_result (Error={badrpc,_},Req,C) ->
+cluster_action_result(Error={badrpc,_},Req,C) ->
     {{error,mochijson2:encode({struct,[Error]})},Req,C};
-cluster_action_result (_,Req,C) ->
+cluster_action_result(_,Req,C) ->
     {mochijson2:encode({struct,[{result,ok}]}),Req,C}.
 
 %% all actions return the same format
-node_action_result ({error,Reason},Req,C) ->
+node_action_result({error,Reason},Req,C) ->
     {{error,Reason},Req,C};
-node_action_result (_,Req,C) ->
+node_action_result(_,Req,C) ->
     {mochijson2:encode({struct,[{result,ok}]}),Req,C}.

--- a/src/riak_control_formatting.erl
+++ b/src/riak_control_formatting.erl
@@ -21,22 +21,17 @@
 %% @doc JSON formatting of result
 -module(riak_control_formatting).
 
--export([cluster_action_result/3, node_action_result/3]).
+-export([action_result/3]).
 
 -include("riak_control.hrl").
 
-%% TODO: combine these two.
-
 %% all actions return the same format
-cluster_action_result(Error={error,_},Req,C) ->
-    {{error,mochijson2:encode({struct,[Error]})},Req,C};
-cluster_action_result(Error={badrpc,_},Req,C) ->
-    {{error,mochijson2:encode({struct,[Error]})},Req,C};
-cluster_action_result(_,Req,C) ->
-    {mochijson2:encode({struct,[{result,ok}]}),Req,C}.
-
-%% all actions return the same format
-node_action_result({error,Reason},Req,C) ->
-    {{error,Reason},Req,C};
-node_action_result(_,Req,C) ->
-    {mochijson2:encode({struct,[{result,ok}]}),Req,C}.
+action_result(Error={badrpc,_},Req,C) ->
+    Body = mochijson2:encode({struct,[Error]}),
+    {false, wrq:set_resp_body(Body, Req), C};
+action_result(Error={error,_},Req,C) ->
+    Body = mochijson2:encode({struct,[Error]}),
+    {false, wrq:set_resp_body(Body, Req), C};
+action_result(_,Req,C) ->
+    Body = mochijson2:encode({struct,[{result,ok}]}),
+    {true, wrq:set_resp_body(Body, Req), C}.

--- a/src/riak_control_formatting.erl
+++ b/src/riak_control_formatting.erl
@@ -1,0 +1,42 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc JSON formatting of result
+-module(riak_control_formatting).
+
+-export([cluster_action_result/3, node_action_result/3]).
+
+-include("riak_control.hrl").
+
+%% TODO: combine these two.
+
+%% all actions return the same format
+cluster_action_result (Error={error,_},Req,C) ->
+    {{error,mochijson2:encode({struct,[Error]})},Req,C};
+cluster_action_result (Error={badrpc,_},Req,C) ->
+    {{error,mochijson2:encode({struct,[Error]})},Req,C};
+cluster_action_result (_,Req,C) ->
+    {mochijson2:encode({struct,[{result,ok}]}),Req,C}.
+
+%% all actions return the same format
+node_action_result ({error,Reason},Req,C) ->
+    {{error,Reason},Req,C};
+node_action_result (_,Req,C) ->
+    {mochijson2:encode({struct,[{result,ok}]}),Req,C}.

--- a/src/riak_control_rpc.erl
+++ b/src/riak_control_rpc.erl
@@ -1,0 +1,39 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc RPC functions.
+-module(riak_control_rpc).
+
+-export([perform_rpc_action/5]).
+
+-include("riak_control.hrl").
+
+%% get the target node for the action
+target_node (Req) ->
+    list_to_existing_atom(dict:fetch(node,wrq:path_info(Req))).
+
+%% remote to the target node, perform the action, and return
+perform_rpc_action (Req,C,Module,Fun,Args) ->
+    Node=target_node(Req),
+    Result=case rpc:call(Node,Module,Fun,Args) of
+               {badrpc,Error} -> {error,Error};
+               Ok -> Ok
+           end,
+    riak_control_formatting:node_action_result(Result,Req,C).

--- a/src/riak_control_rpc.erl
+++ b/src/riak_control_rpc.erl
@@ -36,4 +36,4 @@ perform_rpc_action(Req,C,Module,Fun,Args) ->
                {badrpc,Error} -> {error,Error};
                Ok -> Ok
            end,
-    riak_control_formatting:node_action_result(Result,Req,C).
+    riak_control_formatting:action_result(Result,Req,C).

--- a/src/riak_control_rpc.erl
+++ b/src/riak_control_rpc.erl
@@ -26,11 +26,11 @@
 -include("riak_control.hrl").
 
 %% get the target node for the action
-target_node (Req) ->
+target_node(Req) ->
     list_to_existing_atom(dict:fetch(node,wrq:path_info(Req))).
 
 %% remote to the target node, perform the action, and return
-perform_rpc_action (Req,C,Module,Fun,Args) ->
+perform_rpc_action(Req,C,Module,Fun,Args) ->
     Node=target_node(Req),
     Result=case rpc:call(Node,Module,Fun,Args) of
                {badrpc,Error} -> {error,Error};

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -23,7 +23,9 @@
 
 -export([scheme_is_available/2,
          enforce_auth/2,
-         https_redirect_loc/1
+         https_redirect_loc/1,
+         csrf_token/2,
+         validate_csrf_token/2
         ]).
 
 -include("riak_control.hrl").
@@ -126,3 +128,28 @@ valid_userpass(_User, _Pass, _Auth) ->
     error_logger:warning_msg("Unknown auth type '~p'", [_Auth]),
     false.
 
+%% @doc store a csrf protection token in a cookie.
+csrf_token(RD, Ctx) ->
+    case get_csrf_token(RD, Ctx) of
+        undefined ->
+            binary_to_list(base64:encode(crypto:rand_bytes(256)));
+        Token ->
+            Token
+    end.
+
+get_csrf_token(RD, _Ctx) ->
+    wrq:get_cookie_value("csrf_token", RD).
+
+%% @doc ensure this request contains a valid csrf protection token.
+validate_csrf_token(RD, Ctx) ->
+    Body = mochiweb_util:parse_qs(wrq:req_body(RD)),
+    BodyToken = proplists:get_value("csrf_token", Body),
+    CookieToken = get_csrf_token(RD, Ctx),
+    case BodyToken of
+        undefined ->
+            false;
+        CookieToken ->
+            true;
+        _ ->
+            false
+    end.

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -47,7 +47,7 @@ scheme_is_available(RD, Ctx) ->
     end.
 
 %% get the https location to redirect to (callable w/o a request)
-https_redirect_loc (Path) ->
+https_redirect_loc(Path) ->
     case app_helper:get_env(riak_control, enabled, false) of
         true ->
             case app_helper:get_env(riak_core, https) of
@@ -61,7 +61,7 @@ https_redirect_loc (Path) ->
     end.
 
 %% set the redirect header and where to go with it
-https_redirect (RD,Ctx) ->
+https_redirect(RD,Ctx) ->
     Path=wrq:raw_path(RD),
     Loc=case https_redirect_loc(Path) of
             {ok,Dest} ->

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -146,14 +146,7 @@ is_valid_csrf_token(RD, Ctx) ->
     Body = mochiweb_util:parse_qs(wrq:req_body(RD)),
     BodyToken = proplists:get_value("csrf_token", Body),
     CookieToken = get_csrf_token(RD, Ctx),
-    case BodyToken of
-        undefined ->
-            false;
-        CookieToken ->
-            true;
-        _ ->
-            false
-    end.
+    BodyToken /= undefined andalso BodyToken == CookieToken.
 
 %% @doc Check if the Origin header is "null". This is useful to look for attempts
 %%      at CSRF, but is not a complete answer to the problem.

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -25,7 +25,8 @@
          enforce_auth/2,
          https_redirect_loc/1,
          csrf_token/2,
-         is_valid_csrf_token/2
+         is_valid_csrf_token/2,
+         is_null_origin/1
         ]).
 
 -include("riak_control.hrl").
@@ -149,6 +150,16 @@ is_valid_csrf_token(RD, Ctx) ->
         undefined ->
             false;
         CookieToken ->
+            true;
+        _ ->
+            false
+    end.
+
+%% @doc Check if the Origin header is "null". This is useful to look for attempts
+%%      at CSRF, but is not a complete answer to the problem.
+is_null_origin(RD) ->
+    case wrq:get_req_header("Origin", RD) of
+        "null" ->
             true;
         _ ->
             false

--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -25,7 +25,7 @@
          enforce_auth/2,
          https_redirect_loc/1,
          csrf_token/2,
-         validate_csrf_token/2
+         is_valid_csrf_token/2
         ]).
 
 -include("riak_control.hrl").
@@ -141,7 +141,7 @@ get_csrf_token(RD, _Ctx) ->
     wrq:get_cookie_value("csrf_token", RD).
 
 %% @doc ensure this request contains a valid csrf protection token.
-validate_csrf_token(RD, Ctx) ->
+is_valid_csrf_token(RD, Ctx) ->
     Body = mochiweb_util:parse_qs(wrq:req_body(RD)),
     BodyToken = proplists:get_value("csrf_token", Body),
     CookieToken = get_csrf_token(RD, Ctx),

--- a/src/riak_control_sup.erl
+++ b/src/riak_control_sup.erl
@@ -61,7 +61,8 @@ init([]) ->
                          {admin, admin_cluster_down},
                          {admin, admin_node},
                          {admin, admin_node_stop},
-                         {admin, admin_node_leave}
+                         {admin, admin_node_leave},
+                         {admin, admin_fallbacks}
                         ],
             Routes = lists:append([routes(E, M) || {E, M} <- Resources]),
             [webmachine_router:add_route(R) || R <- Routes],

--- a/src/riak_control_sup.erl
+++ b/src/riak_control_sup.erl
@@ -57,7 +57,11 @@ init([]) ->
                          {admin, admin_overview},
                          {admin, admin_ring},
                          {admin, admin_cluster},
-                         {admin, admin_node}
+                         {admin, admin_cluster_join},
+                         {admin, admin_cluster_down},
+                         {admin, admin_node},
+                         {admin, admin_node_stop},
+                         {admin, admin_node_leave}
                         ],
             Routes = lists:append([routes(E, M) || {E, M} <- Resources]),
             [webmachine_router:add_route(R) || R <- Routes],

--- a/templates/index.dtl
+++ b/templates/index.dtl
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>Riak Control</title>
     <link type="text/css" rel="stylesheet" media="all" href="/admin/ui/style.css" />
+    <meta name="csrf_token" content="{{ csrf_token }}">
 </head>
 
 <!-- when the page finishes loading, start filling in details -->


### PR DESCRIPTION
Add CSRF token prevention to Riak Control.
- Break out resources which perform potentially destructive actions.
- Switch these from GET requests to POST requests.
- No longer serve index.html off of the file system, serve from erlydtl template so we can insert a CSRF token into the header as a meta tag. (Potentially problematic because users might have bookmarked /admin/ui/index.html).

The changes to the API are less than awesome, but are good enough to get us to a place where things feel much safter (POST vs non-idempotent GET).
