### PR TITLE
correct for proper host token ordering fix in webmachine

### DIFF
--- a/src/riak_control_security.erl
+++ b/src/riak_control_security.erl
@@ -68,7 +68,7 @@ https_redirect(RD,Ctx) ->
             {ok,Dest} ->
                 Dest;
             _ ->
-                Host=string:join(lists:reverse(wrq:host_tokens(RD)),"."),
+                Host=string:join(wrq:host_tokens(RD),"."),
                 ["https://",Host,Path]
         end,
     {{halt,303},wrq:set_resp_header("Location",Loc,RD),Ctx}.


### PR DESCRIPTION
This patch is required after https://github.com/basho/webmachine/pull/87 is accepted.
