### PR TITLE
Fix rebar.config to use {branch, "name"}

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 
 {deps, [
        {webmachine, ".*",
-        {git, "git://github.com/basho/webmachine", {tag, "develop"}}},
+        {git, "git://github.com/basho/webmachine", {branch, "develop"}}},
        {riak_core, ".*",
         {git, "git://github.com/basho/riak_core", {branch, "develop"}}},
        {erlydtl, ".*",


### PR DESCRIPTION
Currently rebar.config was using {tag, "develop"}, which is just silly
and sort of work by chance.
