### PR TITLE
riak_control cuttlefish schema and tests

### DIFF
--- a/priv/riak_control.schema
+++ b/priv/riak_control.schema
@@ -1,0 +1,54 @@
+%% riak_control config
+%% @doc Set to 'off' to disable the admin panel.
+{mapping, "riak_control", "riak_control.enabled", [
+  {default, off},
+  {datatype, {enum, [on, off]}}
+]}.
+
+{translation,
+ "riak_control.enabled",
+ fun(Conf) ->
+    Setting = cuttlefish_util:conf_get_value("riak_control", Conf), 
+    case Setting of
+      on -> true;
+      off -> false;
+      _Default -> false
+    end
+ end}.
+
+%% @doc Authentication style used for access to the admin
+%% panel. Valid styles are: off, userlist
+{mapping, "riak_control.auth", "riak_control.auth", [
+  {default, userlist},
+  {datatype, {enum, [off, userlist]}}
+]}.
+
+{translation,
+"riak_control.auth",
+fun(Conf) ->
+  case cuttlefish_util:conf_get_value("riak_control.auth", Conf) of
+    userlist -> userlist;
+    off -> none;
+    _ -> none
+  end
+end}.
+
+%% @doc If auth is set to 'userlist' then this is the
+%% list of usernames and passwords for access to the
+%% admin panel.
+{mapping, "riak_control.user.$username.password", "riak_control.userlist", [
+  {default, "pass"},
+  {include_default, "user"}
+]}.
+
+{translation,
+"riak_control.userlist",
+fun(Conf) ->
+  UserList = lists:filter(
+    fun({K, _V}) -> 
+      cuttlefish_util:fuzzy_variable_match(K, string:tokens("riak_control.user.$username.password", "."))
+    end,
+    Conf),
+  [ {Username, Password} || {[_, _, Username, _], Password} <- UserList ]
+
+end}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 
 {deps, [
        {cuttlefish, ".*",
-        {git, "git://github.com/basho/cuttlefish", {branch, "jd-test-tools"}}},
+        {git, "git://github.com/basho/cuttlefish", {branch, "develop"}}},
        {webmachine, ".*",
         {git, "git://github.com/basho/webmachine", {branch, "develop"}}},
        {riak_core, ".*",

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,8 @@
 {cover_enabled, true}.
 
 {deps, [
+       {cuttlefish, ".*",
+        {git, "git://github.com/basho/cuttlefish", {branch, "jd-test-tools"}}},
        {webmachine, ".*",
         {git, "git://github.com/basho/webmachine", {branch, "develop"}}},
        {riak_core, ".*",

--- a/test/riak_control_schema_test.erl
+++ b/test/riak_control_schema_test.erl
@@ -1,0 +1,28 @@
+-module(riak_control_schema_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+basic_schema_test() ->
+    Config = cuttlefish_unit:generate_config("../priv/riak_control.schema", []),
+
+    cuttlefish_unit:assert_config(Config, "riak_control.enabled", false),
+    cuttlefish_unit:assert_config(Config, "riak_control.auth", userlist),
+    cuttlefish_unit:assert_config(Config, "riak_control.userlist", [{"user","pass"}]),
+    ok.
+
+userlist_schema_test() ->
+    CuttlefishConf = [
+        {["riak_control", "user", "dev", "password"], "1234"},
+        {["riak_control", "user", "admin", "password"], "5678"}
+    ],
+
+    Config = cuttlefish_unit:generate_config("../priv/riak_control.schema", CuttlefishConf),
+
+    cuttlefish_unit:assert_config(Config, "riak_control.userlist.dev", "1234"),
+    cuttlefish_unit:assert_config(Config, "riak_control.userlist.admin", "5678"),
+
+    %% Other than userlist, which we overrode in CuttlefishConf, the others should still be set to defaults:
+    cuttlefish_unit:assert_config(Config, "riak_control.enabled", false),
+    cuttlefish_unit:assert_config(Config, "riak_control.auth", userlist),
+    ok.


### PR DESCRIPTION
Here's the riak_control section of the riak schema and a basic test for validating it.

depends on fixes in https://github.com/basho/cuttlefish/pull/41

rebar.config pulls the appropriate branch, will need to point back at develop when that's merged.
