### PR TITLE
Fix dropdown for replace not not populating correctly

### DIFF
--- a/priv/admin/js/cluster.js
+++ b/priv/admin/js/cluster.js
@@ -488,7 +488,7 @@ minispade.register('cluster', function() {
         var forced = this.$().
           find("input[type='checkbox']:checked").val();
         var replacement = this.$().
-          find("input[type='select']:selected").val();
+          find(".replacement-node-dropdown select").val();
 
         // Make sure we handle the force replace correctly.
         //

--- a/priv/admin/js/templates/current_cluster_item.hbs
+++ b/priv/admin/js/templates/current_cluster_item.hbs
@@ -75,7 +75,12 @@
                             <div class="gui-dropdown-wrapper replacement-node-dropdown">
                                 <div class="gui-dropdown-bg gui-text">Select Replacement Node</div>
                                 <div class="gui-dropdown-cap left"></div>
-                                {{view RiakControl.ClusterItemSelectView prompt="Select Replacement Node" classNames="gui-dropdown" contentBinding="controller.joiningNodes" optionLabelPath="content.name"}}
+                                {{view RiakControl.ClusterItemSelectView
+                                       prompt="Select Replacement Node"
+                                       classNames="gui-dropdown"
+                                       contentBinding="controller.joiningNodes"
+                                       optionLabelPath="content.name"
+                                       optionValuePath="content.name"}}
                             </div>
                             <div class="gui-checkbox-wrapper">
                                 <input class="gui-checkbox" type="checkbox" {{bindAttr name="name" id="forceReplaceCheck"}} value="true" />

--- a/priv/admin/js/templates/staged_cluster_item.hbs
+++ b/priv/admin/js/templates/staged_cluster_item.hbs
@@ -20,7 +20,7 @@
         {{#if isReplaced}}
             <div class="item4 replacing-box">
                 <div class="gui-text field-container inline-block">
-                    <div class="name gui-field">{{replacement}}</div>
+                    <div class="name gui-field">{{content.replacement}}</div>
                 </div>
             </div>
         {{/if}}


### PR DESCRIPTION
```
- Add correct optionValuePath to RiakControl.ClusterItemSelectView
- Change `replacement` to `content.replacement` because once I fixed the dropdown,
  it exposed another bug where the replacement field in the staged plan wasn't populating
```
