### PR TITLE
try/catch for rex error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ EUnit-SASL.log
 priv/admin/js/generated/templates.js
 priv/admin/js/generated/vendor.js
 tags
+erln8.config

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 
-{erl_opts, [warnings_as_errors, debug_info]}.
+{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info]}.
 
 {edoc_opts, [{preprocess, true}]}.
 


### PR DESCRIPTION
If rex is down on a running node, rpc:calls to that node will crash the riak_control appliction. Wrapping them in a try/catch will prevent that.
