### PR TITLE
use exometer metrics

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 
 {deps, [
        {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}},
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer2"}}},
        {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git", {tag, "d20b53f0"}}}
        ]}.
 


### PR DESCRIPTION
This is a new pull request for the Exometer adaptation, with a cleaner commit history (all changes collected into one diff).

See riak [PR #576](https://github.com/basho/riak/pull/576)

The old riak_control PR was #175 (for comment history)
