### PR TITLE
Reflect that the erlydtl dep is a sha and not a tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 {deps, [
        {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "2.0"}}},
-       {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git", {tag, "d20b53f0"}}}
+       {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git", "d20b53f0"}}
        ]}.
 
 {plugin_dir, "src"}.


### PR DESCRIPTION
This is breaking some Rebar experiments for better dependency management, plus it's just wrong.
