### PR TITLE
Bump webmachine to version 1.10.6-basho1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
 {deps, [
-       {webmachine, "1.10.6-basho1", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6-basho1"}}},
+       {webmachine, "1.10.6.*", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6-basho1"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "2.0"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
 {deps, [
-       {webmachine, "1.10.6", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6"}}},
+       {webmachine, "1.10.6-basho1", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6-basho1"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "2.0"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.


### PR DESCRIPTION
This incorporates a patched version of mochiweb that includes a bug fix
for the spurious 400 errors we've been seeing.
