### PR TITLE
Bump webmachine to 1.10.8-basho1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
 {deps, [
-       {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
+       {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.


### PR DESCRIPTION
This pulls in our fix for the spurious 400 error mochiweb bug.
