### PR TITLE
Fixing a typo in the UI message

### DIFF
--- a/priv/admin/js/templates/all_unavailable_chart.hbs
+++ b/priv/admin/js/templates/all_unavailable_chart.hbs
@@ -10,7 +10,7 @@
   <section class="details">
     <div class="actions-pointer actions-pointer-right"></div>
     <h4 class="gui-headline-bold">
-      Preference lists where all primary repliacs are unavailable.
+      Preference lists where all primary replicas are unavailable.
     </h4>
     {{#if allUnavailableExist}}
     {{allUnavailableCount}} partitions have all of their

--- a/priv/admin/js/templates/quorum_unavailable_chart.hbs
+++ b/priv/admin/js/templates/quorum_unavailable_chart.hbs
@@ -11,7 +11,7 @@
   <section class="details">
     <div class="actions-pointer actions-pointer-center"></div>
     <h4 class="gui-headline-bold">
-      Preference lists where a majority of primary repliacs are unavailable.
+      Preference lists where a majority of primary replicas are unavailable.
     </h4>
     {{#if quorumUnavailableExist}}
     {{quorumUnavailableCount}} partitions have a majority


### PR DESCRIPTION
The 'Riak Control -> Ring' page has a small typo 'repliacs' instead of 'replicas'.
