### PR TITLE
Use webmachine branch rather than tag in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
 {deps, [
-       {webmachine, "1.10.6.*", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6-basho1"}}},
+       {webmachine, ".*", {git, "git://github.com/basho/webmachine.git", {branch, "1.10.6-basho"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "2.0"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.


### PR DESCRIPTION
facilitates building the 2.0 branch between releases.
