### PR TITLE
Kill some more Dialyzer warnings

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,4 +1,3 @@
-riak_control_session.erl:534: The pattern MemberInfo = {'member_info_v2', _, _, _, _, _, _, _, _, _, _, _, _} can never match the type #member_info{node::atom(),status::'down' | 'incompatible' | 'invalid' | 'leaving' | 'transitioning' | 'undefined' | 'valid',reachable::'false' | 'true' | 'undefined',vnodes::'undefined' | [{_,_}],handoffs::'undefined' | [{_,_,_}],ring_pct::'undefined' | float(),pending_pct::'undefined' | float(),mem_total::'undefined' | integer(),mem_used::'undefined' | integer(),mem_erlang::'undefined' | integer()}
 Unknown types:
   webmachine_dispatcher:matchterm/0
   wrq:reqdata/0

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,12 +1,4 @@
 riak_control_session.erl:534: The pattern MemberInfo = {'member_info_v2', _, _, _, _, _, _, _, _, _, _, _, _} can never match the type #member_info{node::atom(),status::'down' | 'incompatible' | 'invalid' | 'leaving' | 'transitioning' | 'undefined' | 'valid',reachable::'false' | 'true' | 'undefined',vnodes::'undefined' | [{_,_}],handoffs::'undefined' | [{_,_,_}],ring_pct::'undefined' | float(),pending_pct::'undefined' | float(),mem_total::'undefined' | integer(),mem_used::'undefined' | integer(),mem_erlang::'undefined' | integer()}
-Unknown functions:
-  rebar_config:get_local/3
-  rebar_js_uglifier_plugin:compress/3
-  rebar_log:log/3
-  rebar_utils:abort/0
-  rebar_utils:sh/2
 Unknown types:
-  riak_core:ring/0
-  riak_core_ring:pending_change/0
   webmachine_dispatcher:matchterm/0
   wrq:reqdata/0

--- a/include/riak_control.hrl
+++ b/include/riak_control.hrl
@@ -32,8 +32,6 @@
 -type handoffs()      :: [handoff()].
 -type vnodes()        :: [vnode()].
 -type plan()          :: [] | legacy | ring_not_ready | unavailable.
--type transfer()      :: riak_core_ring:pending_change().
--type transfers()     :: [transfer()].
 -type single_n_val()  :: pos_integer().
 -type n_vals()        :: [pos_integer()].
 

--- a/src/riak_control_ring.erl
+++ b/src/riak_control_ring.erl
@@ -30,7 +30,7 @@
 -include("riak_control.hrl").
 
 %% @doc Return the ring.
--spec ring() -> riak_core:ring().
+-spec ring() -> riak_core_ring:riak_core_ring().
 ring() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     Ring.
@@ -43,7 +43,7 @@ n_val() ->
     NVal.
 
 %% @doc Return list of nodes, available partition and quorum.
--spec status(riak_core:ring(), list(node())) ->
+-spec status(riak_core_ring:riak_core_ring(), list(node())) ->
     list({number(), number(), number()}).
 status(Ring, Unavailable) ->
     NVal = n_val(),
@@ -51,14 +51,14 @@ status(Ring, Unavailable) ->
     status(Ring, NVal, Quorum, Unavailable).
 
 %% @doc Return list of nodes, available partition and quorum.
--spec status(riak_core:ring(), number(), list(node())) ->
+-spec status(riak_core_ring:riak_core_ring(), number(), list(node())) ->
     list({number(), number(), number()}).
 status(Ring, NVal, Unavailable) ->
     Quorum = mochinum:int_ceil(NVal / 2),
     status(Ring, NVal, Quorum, Unavailable).
 
 %% @doc Return list of nodes, available partition and quorum.
--spec status(riak_core:ring(), number(), number(), list(node())) ->
+-spec status(riak_core_ring:riak_core_ring(), number(), number(), list(node())) ->
     list({number(), number(), number()}).
 status(Ring, NVal, Quorum, Unavailable) ->
     Preflists = riak_core_ring:all_preflists(Ring, NVal),

--- a/src/riak_control_session.erl
+++ b/src/riak_control_session.erl
@@ -64,7 +64,6 @@
                 partitions    :: partitions(),
                 nodes         :: members(),
                 update_tick   :: boolean(),
-                transfers     :: transfers(),
                 n_vals        :: n_vals(),
                 default_n_val :: pos_integer()}).
 
@@ -186,7 +185,6 @@ init([]) ->
     State=#state{vsn=1,
                  nodes=[],
                  services=[],
-                 transfers=[],
                  partitions=[],
                  update_tick=false},
 

--- a/src/riak_control_session.erl
+++ b/src/riak_control_session.erl
@@ -528,10 +528,8 @@ maybe_stage_change(Node, Action, Replacement) ->
 
 %% @doc Conditionally upgrade member info records once they cross node
 %%      boundaries.
--spec upgrade_member_info(member() | #member_info{}) -> member().
-upgrade_member_info(MemberInfo = ?MEMBER_INFO{}) ->
-    MemberInfo;
-upgrade_member_info(MemberInfo = #member_info{}) ->
+-spec upgrade_member_info(#member_info{}) -> member().
+upgrade_member_info(MemberInfo) ->
     ?MEMBER_INFO{
         node = MemberInfo#member_info.node,
         status = MemberInfo#member_info.status,


### PR DESCRIPTION
This PR cleans up some dead lines in dialyzer.ignore-warnings, and also fixes a few warnings that were being suppressed. All the fixes were pretty trivial, and involved fixing type specs or removing dead code.